### PR TITLE
Added: dataset_id identifier to prevent overwriting after kfold data …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 # C extensions
 *.so
 *.gitignore
-
+benchmarks/
 # Distribution / packaging
 .Python
 build/

--- a/reproducibility/evaluator.py
+++ b/reproducibility/evaluator.py
@@ -204,6 +204,7 @@ class Evaluator:
         filters,
         split,
         method_params,
+        dataset_id=None,
         epochs=None,
         report_best_val_score_epoch=False,
         apply_resampling=False,
@@ -214,6 +215,7 @@ class Evaluator:
         self.train_dataset = train_dataset
         self.test_dataset = test_dataset
         self.filters = filters
+        self.dataset_id = dataset_id
         self.epochs = epochs
         self.split = split
         self.apply_resampling = apply_resampling
@@ -292,6 +294,7 @@ class Evaluator:
             train_dataset=self.train_dataset,
             test_dataset=self.test_dataset,
             split=self.split,
+            dataset_id=self.dataset_id
             epochs=self.epochs,
             resample_while_keeping_total_waveforms_fixed=self.resample_while_keeping_total_waveforms_fixed,
             method_params=self.method_params,

--- a/reproducibility/kfold_environment.py
+++ b/reproducibility/kfold_environment.py
@@ -94,6 +94,7 @@ class KFoldEnvironment:
     def __init__(
         self,
         dataset,
+        dataset_id=None,
         preprocessed_dataset_directory=PREPROCESSED_DATASET_DIRECTORY,
         batch_size=BATCH_SIZE,
         stead_time_window=STEAD_TIME_WINDOW,
@@ -207,18 +208,18 @@ class KFoldEnvironment:
 
         # Saves the chunk dataframes.
         makedirs(join(self.preprocessed_dataset_directory, self.dataset), exist_ok=True)
+        identifier = dataset_id or self.dataset
         if self.apply_resampling:
             metadata_path = join(
                 self.preprocessed_dataset_directory, 
                 self.dataset, 
-                "resampled_eq{}_subsampled_{}percent.csv".format(int(100 * self.resample_eq_ratio),
-                                                                int(100 * self.subsampling_factor)),
+                f"{identifier}_resampled_eq{int(100 * self.resample_eq_ratio)}_subsampled_{int(100 * self.subsampling_factor)}percent.csv"
             )
         else:
             metadata_path = join(
                 self.preprocessed_dataset_directory, 
                 self.dataset, 
-                "subsampled_{}percent.csv".format(int(100 * self.subsampling_factor)),
+                f"{identifier}_subsampled_{int(100 * self.subsampling_factor)}percent.csv"
             )
             
         if not exists(metadata_path):
@@ -551,13 +552,12 @@ class KFoldEnvironment:
         if self.apply_resampling:
             processed_hdf5_path = join(
                 processed_hdf5_dir,
-                "resampled_eq{}_subsampled_{}percent.hdf5".format(int(100 * self.resample_eq_ratio),
-                                                                  int(100 * self.subsampling_factor)),
+                f"{identifier}_resampled_eq{int(100 * self.resample_eq_ratio)}_subsampled_{int(100 * self.subsampling_factor)}percent.hdf5"
             )
         else:
             processed_hdf5_path = join(
                 processed_hdf5_dir,
-                "subsampled_{}percent.hdf5".format(int(100 * self.subsampling_factor)),
+                f"{identifier}_subsampled_{int(100 * self.subsampling_factor)}percent.hdf5"
             )
         
         # Creates preprocessed dataset if not exists. Otherwise, loads it.

--- a/reproducibility/kfold_tester.py
+++ b/reproducibility/kfold_tester.py
@@ -19,9 +19,11 @@ class KFoldTester:
         apply_resampling,
         resample_while_keeping_total_waveforms_fixed,
         resample_eq_ratio,
+        dataset_id=None,
         method_params={},
     ):
         self.exp_name = exp_name
+        self.dataset_id = dataset_id
         self.representation_learning_model_class = representation_learning_model_class
         self.classifer_model_class = classifier_model_class
         self.train_dataset = train_dataset
@@ -127,6 +129,7 @@ class KFoldTester:
 
     def _add_test_environment(self):
         self.test_environment = KFoldEnvironment(self.test_dataset,
+                                                 dataset_id=self.dataset_id,
                                                  apply_resampling=self.apply_resampling,
                                                  resample_eq_ratio=self.resample_eq_ratio,
                                                  resample_while_keeping_total_waveforms_fixed=self.resample_while_keeping_total_waveforms_fixed)

--- a/reproducibility/kfold_trainer.py
+++ b/reproducibility/kfold_trainer.py
@@ -26,6 +26,7 @@ class KfoldTrainer:
         dataset,
         split,
         epochs,
+        dataset_id=None,
         apply_resampling=False,
         resampling_eq_ratio=0.5,
         resample_while_keeping_total_waveforms_fixed=False,
@@ -54,6 +55,7 @@ class KfoldTrainer:
     ):
         kfold_env = KFoldEnvironment(
             dataset=self.dataset,
+            dataset_id=self.dataset_id,
             apply_resampling=self.apply_resampling,
             resample_eq_ratio=self.resampling_eq_ratio,
             resample_while_keeping_total_waveforms_fixed=self.resample_while_keeping_total_waveforms_fixed

--- a/reproducibility/testing.py
+++ b/reproducibility/testing.py
@@ -15,7 +15,6 @@ CLASSIFIER_MODEL_CLASS = ClassifierMultipleAutoencoder
 
 # Split.
 SPLIT = 0
-
 rows = []
 
 def _eval_resamplings(experiment_prefix, df_path):
@@ -30,6 +29,7 @@ def _eval_resamplings(experiment_prefix, df_path):
                 evaluator = Evaluator(exp_name = f"{experiment_prefix}{resample_eq_ratio}", 
                                       representation_learning_model_class=REPRESENTATION_LEARNING_MODEL_CLASS, 
                                       classifier_model_class = CLASSIFIER_MODEL_CLASS, 
+                                      dataset_id= 'SLVT'
                                       train_dataset = train_set, 
                                       test_dataset = test_set, 
                                       filters = filters, 
@@ -87,6 +87,7 @@ def _plot_roc(experiment_prefix, resample_eq_ratio):
     plt.legend()
     plt.grid(True)
     plt.savefig("tpr-fpr.png")
-    
+STATION_NAMES=['ADVT','ARMT','BGKT','CTKS','ERIK','GELI','GONE','SLVT', 'ADVT_1fold']
 #_plot_roc("exp_resample_eq_ratio", 0.1)
-_eval_resamplings("exp_instance_resample_eq_ratio", "/home/onur/Code/recovar/resampling_vs_score.csv")  
+for STATION in STATION_NAMES:
+    _eval_resamplings('exp_'+STATION, f"/home/ege/recovar/ADVT_resample_station_scores.csv")  

--- a/reproducibility/training.py
+++ b/reproducibility/training.py
@@ -9,25 +9,25 @@ from config import KFOLD_SPLITS
 MODEL_CLASSES = [RepresentationLearningMultipleAutoencoder]
 
 # Should be stead or instance.
-DATASETS = ["instance"]
+DATASETS = ["custom"]
 
 # Number of epochs
-NUM_EPOCHS = 40
-
+NUM_EPOCHS = 10
 # For all splits, train the model over defined datasets.
 for eq_ratio in [0.01, 0.02, 0.03, 0.04, 0.05]:
     for train_dataset in DATASETS:
         for model_class in MODEL_CLASSES:
             for split in range(1):
-                exp_name = f"exp_instance_resample_eq_ratio{eq_ratio}"
+                exp_name = f"exp_SLVT_resample_eq_ratio{eq_ratio}"
                 kfold_trainer = KfoldTrainer(
-                    exp_name, 
+                    exp_name,
+                    dataset_id="SLVT",
                     model_class, 
                     train_dataset, 
                     split, 
                     epochs=NUM_EPOCHS, 
                     apply_resampling=True, 
-                    resample_while_keeping_total_waveforms_fixed=True,
+                    resample_while_keeping_total_waveforms_fixed=False,
                     resampling_eq_ratio=eq_ratio
                 )
                 kfold_trainer.train()


### PR DESCRIPTION
…preprocessing while keeping cache functionality. Datasets were saved with the same name after kfold preprocessing, which caused overwriting problems etc. Added the identifier dataset_id, which solves the issue but keeps the caching functionality so the same dataset doesn't get processed twice.